### PR TITLE
Add support for Python distributable wheels

### DIFF
--- a/mfile/__init__.py
+++ b/mfile/__init__.py
@@ -1,6 +1,2 @@
-from .erg import ERG
-from .version import __version__
-
-class BSIG:
-
-    pass
+from .erg import *
+from .version import *

--- a/mfile/__init__.py
+++ b/mfile/__init__.py
@@ -1,2 +1,6 @@
 from .erg import *
 from .version import *
+
+
+class BSIG:
+    pass

--- a/mfile/version.py
+++ b/mfile/version.py
@@ -1,4 +1,8 @@
 # -*- coding: utf-8 -*-
 """ mfile version module """
 
+
+__all__ = ['__version__']
+
+
 __version__ = "0.1"

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,45 @@
+''' This file allows pip to create a wheel for the mfile package. '''
+
+
+from setuptools import setup
+from pathlib import Path
+
+from mfile import __version__
+
+
+HERE = Path(__file__)
+REPO = HERE.parent
+README = REPO / 'README.md'
+
+
+if not README.exists():
+    raise FileNotFoundError('README.md must missing in top directory')
+
+
+setup(
+    name='mfile',
+    version=__version__,
+    description='Python parser for CarMaker ERG files.',
+    long_description=README.read_text(),
+    long_description_content_type='text/markdown',
+    url='https://github.com/danielhrisca/mfile',
+    author='Daniel Hrisca',
+    author_email='daniel.hrisca@gmail.com',
+    license='MIT',
+    classifiers=[
+        'Development Status :: 3 - Alpha',
+        'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+    ],
+    keywords='carmaker erg development',
+    packages=['mfile'],
+    # Because of pathlib it has to be >=3.4 and ~ is because we are not
+    # committing to support python4.
+    # See: https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires
+    python_requires='~=3.4',
+    install_requires=['asammdf', 'numpy'],
+)


### PR DESCRIPTION
This will make possible to build a wheel with the aim of uploading it to PyPI so it can be pip-installed.